### PR TITLE
test: selenium 연동 테스트 CLI 환경에서도 적용 가능하도록 수정.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -9,5 +9,4 @@ if (hasProperty('enableLocalTest') && (enableLocalTest as String).toBoolean()) {
     println("로컬 테스트 폴더는 포함되지 않습니다.")
 }
 
-// TODO - selenium 기반 테스트도 터미널 창에서도 실행될 수 있도록 설정하기.
 // TODO - github actions에서 jacoco 실행하도록 한 뒤 커버리지 수치를 배지로 표현할 수 있도록 하기.

--- a/spoonsuits-local-test/build.gradle
+++ b/spoonsuits-local-test/build.gradle
@@ -56,7 +56,10 @@ dependencies {
 
 	// 웹 브라우저 환경에서의 자동화 테스트를 위한 프레임워크
 	// https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-java
-	implementation 'org.seleniumhq.selenium:selenium-java:4.30.0'
+	testImplementation 'org.seleniumhq.selenium:selenium-java:4.30.0'
+
+	// 시스템에 설정된 크롬 브라우저 버전과 셀레니움 라이브러리 버전 간 호환을 위함.
+	testImplementation 'org.seleniumhq.selenium:selenium-devtools-v139:4.35.0'
 }
 
 tasks.named('test') {

--- a/spoonsuits-local-test/src/test/java/com/jerocaller/test/spoonsuits_local_test/spoonsuits_local_test/config/SeleniumOptionConfigUtils.java
+++ b/spoonsuits-local-test/src/test/java/com/jerocaller/test/spoonsuits_local_test/spoonsuits_local_test/config/SeleniumOptionConfigUtils.java
@@ -1,0 +1,36 @@
+package com.jerocaller.test.spoonsuits_local_test.spoonsuits_local_test.config;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SeleniumOptionConfigUtils {
+
+    /**
+     * <p>
+     *     Selenium을 이용한 모든 테스트에 적용할 Chrome option.
+     * </p>
+     * <p>
+     *     여기서는 GUI를 지원하지 않는 리눅스와 같은 OS 환경에서도 Selenium 테스트가 진행될 수 있도록
+     *     브라우저 GUI 창 띄우기를 방지하도록 설정함.
+     * </p>
+     *
+     * @return
+     */
+    public static ChromeOptions getChromeOption() {
+        ChromeOptions chromeOptions = new ChromeOptions();
+
+        // 헤드리스 모드 활성화. 셀레니움 테스트 실행 시 브라우저 화면을 화면에 띄우지 않고,
+        // 메모리 상에서만 실행하는 방식. 특히 GUI를 지원하지 않는 리눅스 등의 OS 환경에서 사용.
+        chromeOptions.addArguments("--headless");
+        chromeOptions.addArguments("--no-sandbox");
+
+        // 리눅스와 같은 OS 환경에서 공유 메모리(`/dev/shm`) 공간 사용 시
+        // 해당 공간이 매우 적게 할당되어 Chrome이 차지하는 메모리 용량이 이를 넘길 경우 문제가 발생할 수 있음.
+        // 따라서 해당 공유 메모리 사용을 하지 않고 일반 파일 시스템(`/tmp`)을 사용하도록 함.
+        chromeOptions.addArguments("--disable-dev-shm-usage");
+
+        return chromeOptions;
+    }
+}

--- a/spoonsuits-local-test/src/test/java/com/jerocaller/test/spoonsuits_local_test/spoonsuits_local_test/config/TestCookieConfigurer.java
+++ b/spoonsuits-local-test/src/test/java/com/jerocaller/test/spoonsuits_local_test/spoonsuits_local_test/config/TestCookieConfigurer.java
@@ -5,8 +5,6 @@ import jakarta.servlet.http.Cookie;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-@Primary
-@Component
 public class TestCookieConfigurer implements CookieConfigurer {
 
     @Override

--- a/spoonsuits-local-test/src/test/java/com/jerocaller/test/spoonsuits_local_test/spoonsuits_local_test/controller/cookie/CookieControllerWithCustomCookieConfigurerTest.java
+++ b/spoonsuits-local-test/src/test/java/com/jerocaller/test/spoonsuits_local_test/spoonsuits_local_test/controller/cookie/CookieControllerWithCustomCookieConfigurerTest.java
@@ -1,5 +1,6 @@
 package com.jerocaller.test.spoonsuits_local_test.spoonsuits_local_test.controller.cookie;
 
+import com.jerocaller.libs.spoonsuits.web.cookie.CookieConfigurer;
 import com.jerocaller.libs.spoonsuits.web.cookie.CookieUtils;
 import com.jerocaller.test.spoonsuits_local_test.spoonsuits_local_test.config.TestCookieConfigurer;
 import com.jerocaller.test.spoonsuits_local_test.spoonsuits_local_test.config.TestSecurityDisableConfig;
@@ -10,7 +11,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -24,6 +28,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = {TestSecurityDisableConfig.class})
 @Slf4j
 class CookieControllerWithCustomCookieConfigurerTest {
+
+    @TestConfiguration
+    static class CustomConfig {
+
+        @Bean
+        @Primary
+        public CookieConfigurer cookieConfigurer() {
+            return new TestCookieConfigurer();
+        }
+    }
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
- 각 테스트 모듈간 독립성 확보 - TestCookieConfiguer를 특정 테스트 클래스 내에서만 사용 가능하도록 변경.
- selenium 연동 테스트 관련 오류 수정 후 jacoco code coverage 81% -> 92%으로 상승.

Resolves: #77